### PR TITLE
Update donation links and add funding model platforms

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,5 @@
+# These are supported funding model platforms
+
+# github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+buy_me_a_coffee: narainkarthikv
+ko_fi: wisdomfox

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -383,12 +383,12 @@ const preview = '/app-banner.png';
                 ☕ Buy us a coffee
               </a>
               <a
-                href="https://patreon.com/user?u=72747187"
+                href=" https://buymeacoffee.com/narainkarthikv"
                 target="_blank"
                 rel="noopener noreferrer"
                 class="inline-flex items-center gap-2 rounded-lg bg-[var(--color-action-default)] px-6 py-3 text-sm font-semibold text-[var(--color-text-inverse)] transition-colors hover:bg-[var(--color-action-hover)]"
               >
-                💚 Support on Patreon
+                💚 Support on Buymeacoffee
               </a>
             </div>
             <p class="mt-6 text-xs text-[var(--color-text-secondary)]">


### PR DESCRIPTION
This pull request updates the project's funding and support links, migrating from Patreon to Buy Me a Coffee.

Changes Made
Added funding configuration (.github/FUNDING.yml):

Configured Buy Me a Coffee as the primary funding platform with username narainkarthikv
Added Ko-fi as an alternative funding platform with username wisdomfox
Updated homepage support links (src/pages/index.astro):

Changed the "Support on Patreon" button link from https://patreon.com/user?u=72747187 to https://buymeacoffee.com/narainkarthikv
Updated button text from "💚 Support on Patreon" to "💚 Support on Buymeacoffee"